### PR TITLE
Added warning codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const logModes = require('./lib/logModes');
 const queuePositions = require('./lib/queue-positions');
 const errorsCode = require('./lib/errors-code');
 const podStatus = require('./lib/pod-statuses');
+const warningCodes = require('./lib/warning-codes');
 
 module.exports = {
     boardStatuses,
@@ -34,5 +35,6 @@ module.exports = {
     logModes,
     queuePositions,
     errorsCode,
-    podStatus
+    podStatus,
+    warningCodes
 };

--- a/lib/warning-codes.js
+++ b/lib/warning-codes.js
@@ -1,0 +1,4 @@
+module.exports = {
+    INVALID_VOLUME: 1001, // Invalid or missing volume
+    RESOURCES: 1002, // Insufficient resources (CPU, memory, etc.)
+};


### PR DESCRIPTION
New warning codes have been added.
Related issue: https://github.com/kube-HPC/hkube/issues/1821
Related PR: https://github.com/kube-HPC/hkube/pull/2033
**Reason:**
The system now differentiates between two types of warnings: one related to resource issues and another related to invalid volumes. To clearly indicate which type of warning is being generated, new constants have been introduced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/consts.hkube/21)
<!-- Reviewable:end -->
